### PR TITLE
fix(hero): image doesn't stretch anymore

### DIFF
--- a/css/css/index/style.css
+++ b/css/css/index/style.css
@@ -598,6 +598,7 @@ footer a {
 }
 
 .top_content_img {
+  flex: 1;
   display: flex;
   width: 100%;
   align-items: center;
@@ -614,11 +615,13 @@ footer a {
 }
 
 .android_img {
+  width: 90%;
   height: 90%;
-  width: 40%;
+  object-fit: contain;
 }
 
 .top_content_data {
+  flex: 1;
   display: flex;
   width: 100%;
   flex-direction: column;


### PR DESCRIPTION
Closes #305 

The two main elements of the hero on desktop are now sized equally, and the image will take up to the 90% of available width and height, never stretching thanks to `object-fit`.

### Screenshot
![Fix](https://media.giphy.com/media/RfHXV4p4z7gjeGo5gb/giphy.gif)
